### PR TITLE
Adding active bigip status into ansible playbooks

### DIFF
--- a/etc/dehydrated/ansible/playbooks/bigip-clean_challenge.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-clean_challenge.yml
@@ -26,6 +26,17 @@
       retries: 10
       delay: 6
 
+    - name: Collect BIG-IP information
+      bigip_device_info:
+        gather_subset: devices
+        provider:
+          user: "{{ bigip_user }}"
+          password: "{{ bigip_password }}"
+          server: "{{ inventory_hostname }}"
+          validate_certs: no
+      register: devices
+      delegate_to: localhost
+
     - name: Update data group
       bigip_data_group:
         name: "{{ data_group_name }}"
@@ -33,6 +44,7 @@
         records: []
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Sync configuration from device to group
       bigip_configsync_action:
@@ -40,4 +52,5 @@
         sync_device_to_group: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: sync_config == "1"
+      when: sync_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
+

--- a/etc/dehydrated/ansible/playbooks/bigip-configure-acme-http-01.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-configure-acme-http-01.yml
@@ -25,6 +25,17 @@
       retries: 10
       delay: 6
 
+    - name: Collect BIG-IP information
+      bigip_device_info:
+        gather_subset: devices
+        provider:
+          user: "{{ bigip_user }}"
+          password: "{{ bigip_password }}"
+          server: "{{ inventory_hostname }}"
+          validate_certs: no
+      register: devices
+      delegate_to: localhost
+
     - name: Create ACME HTTP-01 challenge response iRule
       bigip_irule:
         module: ltm
@@ -54,6 +65,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Create a data group for ACME HTTP-01 validation
       bigip_data_group:
@@ -67,13 +79,14 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Save the running configuration of the BIG-IP
       bigip_config:
         save: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: save_config == "1"
+      when: save_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Sync configuration from device to group
       bigip_configsync_action:
@@ -81,4 +94,5 @@
         sync_device_to_group: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: sync_config == "1"
+      when: sync_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
+

--- a/etc/dehydrated/ansible/playbooks/bigip-configure-lets-encrypt-ocsp-stapling.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-configure-lets-encrypt-ocsp-stapling.yml
@@ -25,6 +25,17 @@
       retries: 10
       delay: 6
 
+    - name: Collect BIG-IP information
+      bigip_device_info:
+        gather_subset: devices
+        provider:
+          user: "{{ bigip_user }}"
+          password: "{{ bigip_password }}"
+          server: "{{ inventory_hostname }}"
+          validate_certs: no
+      register: devices
+      delegate_to: localhost
+
     - name: Create basic DNS resolver configuration for OCSP stapling
       bigip_dns_resolver:
         partition: "{{ bigip_partition }}"
@@ -32,6 +43,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Add Let's Encrypt Staging X1 CA certificate
       bigip_ssl_certificate:
@@ -68,6 +80,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Add Let's Encrypt X3 CA certificate
       bigip_ssl_certificate:
@@ -104,6 +117,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Create OCSP stapling profile for Let's Encrypt Staging X1 CA
       bigip_ssl_ocsp:
@@ -123,6 +137,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Create OCSP stapling profile for Let's Encrypt X3 CA
       bigip_ssl_ocsp:
@@ -142,13 +157,14 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Save the running configuration of the BIG-IP
       bigip_config:
         save: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: save_config == "1"
+      when: save_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Sync configuration from device to group
       bigip_configsync_action:
@@ -156,4 +172,5 @@
         sync_device_to_group: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: sync_config == "1"
+      when: sync_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
+

--- a/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-management.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-management.yml
@@ -9,15 +9,31 @@
     ansible_password: "{{ bigip_ssh_password }}"
 
   tasks:
+
+    - name: Collect BIG-IP information
+      bigip_device_info:
+        gather_subset: devices
+        provider:
+          user: "{{ bigip_user }}"
+          password: "{{ bigip_password }}"
+          server: "{{ inventory_hostname }}"
+          validate_certs: no
+      register: devices
+      delegate_to: localhost
+
     - name: upload cert
       copy:
         src: "{{ cert_file }}"
         dest: "/etc/httpd/conf/ssl.crt/server.crt"
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: upload key
       copy:
         src: "{{ key_file }}"
         dest: "/etc/httpd/conf/ssl.key/server.key"
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: change management cert
       command: tmsh restart /sys service httpd
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
+

--- a/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-traffic.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-traffic.yml
@@ -25,6 +25,17 @@
       retries: 10
       delay: 6
 
+    - name: Collect BIG-IP information
+      bigip_device_info:
+        gather_subset: devices
+        provider:
+          user: "{{ bigip_user }}"
+          password: "{{ bigip_password }}"
+          server: "{{ inventory_hostname }}"
+          validate_certs: no
+      register: devices
+      delegate_to: localhost
+
     - name: Create/update key for cert
       bigip_ssl_key:
         partition: "{{ bigip_partition }}"
@@ -33,6 +44,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Create/update certificate
       bigip_ssl_certificate:
@@ -43,13 +55,14 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Enable OCSP validation/monitoring on certificate
       bigip_command:
         commands: "modify sys file ssl-cert {{ cert_name }}.crt { cert-validators replace-all-with { OCSP-STAPLE-{{ cert_issuer }} } cert-validation-options { ocsp } }"
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: ocsp_staple == "1"
+      when: ocsp_staple == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Create/update certificate chain
       bigip_ssl_certificate:
@@ -59,6 +72,7 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Create/update client SSL profile
       bigip_profile_client_ssl:
@@ -72,21 +86,21 @@
         state: present
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: clientssl_manage == "1"
+      when: clientssl_manage == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Enable OCSP validation/monitoring on client SSL profile
       bigip_command:
         commands: "modify ltm profile client-ssl {{ clientssl_name }} ocsp-stapling enabled"
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: ocsp_staple == "1"
+      when: ocsp_staple == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Save the running configuration of the BIG-IP
       bigip_config:
         save: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: save_config == "1"
+      when: save_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Sync configuration from device to group
       bigip_configsync_action:
@@ -94,4 +108,5 @@
         sync_device_to_group: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: sync_config == "1"
+      when: sync_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
+

--- a/etc/dehydrated/ansible/playbooks/bigip-deploy_challenge.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-deploy_challenge.yml
@@ -1,4 +1,3 @@
-
 ---
 
 - name: version
@@ -26,6 +25,17 @@
       retries: 10
       delay: 6
 
+    - name: Collect BIG-IP information
+      bigip_device_info:
+        gather_subset: devices
+        provider:
+          user: "{{ bigip_user }}"
+          password: "{{ bigip_password }}"
+          server: "{{ inventory_hostname }}"
+          validate_certs: no
+      register: devices
+      delegate_to: localhost
+
     - name: Update data group
       bigip_data_group:
         name: "{{ data_group_name }}"
@@ -35,6 +45,7 @@
             value: "{{ key_value }}"
         provider: "{{ provider }}"
       delegate_to: localhost
+      when: inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
 
     - name: Sync configuration from device to group
       bigip_configsync_action:
@@ -42,4 +53,5 @@
         sync_device_to_group: yes
         provider: "{{ provider }}"
       delegate_to: localhost
-      when: sync_config == "1"
+      when: sync_config == "1" and inventory_hostname == (devices.devices | selectattr('failover_state', 'search', 'active') | list | first).name
+


### PR DESCRIPTION
Leveraging the bigip_device_info module to determine which F5 in a cluster is the active unit. Added conditional statements to the subsequent tasks so they are only run IF they are the active unit.