### PR TITLE
Fix "undefined" username and sync variable errors

### DIFF
--- a/etc/dehydrated/ansible/hooks/bigip-traffic-http-01.sh
+++ b/etc/dehydrated/ansible/hooks/bigip-traffic-http-01.sh
@@ -20,7 +20,7 @@ deploy_challenge() {
 
   ansible-playbook ${ANSIBLE_ARGS} \
     --inventory=${ANSIBLE_INVENTORY} \
-    --extra-vars "bigip_partition=${BIGIP_PARTITION} data_group_name=${BIGIP_DATA_GROUP_NAME} key_name=${TOKEN_FILENAME} key_value=${TOKEN_VALUE} ${ANSIBLE_EXTRA_VARS}" \
+    --extra-vars "bigip_partition=${BIGIP_PARTITION} data_group_name=${BIGIP_DATA_GROUP_NAME} key_name=${TOKEN_FILENAME} key_value=${TOKEN_VALUE} sync_config=${BIGIP_SYNC_CONFIG} sync_device_group=${BIGIP_SYNC_DEVICE_GROUP} ${ANSIBLE_EXTRA_VARS}" \
     ${ANSIBLE_PLAYBOOK_DEPLOY_CHALLENGE}
 
   return ${?}
@@ -35,7 +35,7 @@ clean_challenge() {
 
   ansible-playbook ${ANSIBLE_ARGS} \
     --inventory=${ANSIBLE_INVENTORY} \
-    --extra-vars "bigip_partition=${BIGIP_PARTITION} data_group_name=${BIGIP_DATA_GROUP_NAME} key_name=${TOKEN_FILENAME} key_value=${TOKEN_VALUE} ${ANSIBLE_EXTRA_VARS}" \
+    --extra-vars "bigip_partition=${BIGIP_PARTITION} data_group_name=${BIGIP_DATA_GROUP_NAME} key_name=${TOKEN_FILENAME} key_value=${TOKEN_VALUE} sync_config=${BIGIP_SYNC_CONFIG} sync_device_group=${BIGIP_SYNC_DEVICE_GROUP} ${ANSIBLE_EXTRA_VARS}" \
     ${ANSIBLE_PLAYBOOK_CLEAN_CHALLENGE}
 
   return ${?}

--- a/etc/dehydrated/ansible/playbooks/bigip-clean_challenge.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-clean_challenge.yml
@@ -30,7 +30,7 @@
       bigip_device_info:
         gather_subset: devices
         provider:
-          user: "{{ bigip_user }}"
+          user: "{{ bigip_username }}"
           password: "{{ bigip_password }}"
           server: "{{ inventory_hostname }}"
           validate_certs: no

--- a/etc/dehydrated/ansible/playbooks/bigip-configure-acme-http-01.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-configure-acme-http-01.yml
@@ -29,7 +29,7 @@
       bigip_device_info:
         gather_subset: devices
         provider:
-          user: "{{ bigip_user }}"
+          user: "{{ bigip_username }}"
           password: "{{ bigip_password }}"
           server: "{{ inventory_hostname }}"
           validate_certs: no

--- a/etc/dehydrated/ansible/playbooks/bigip-configure-lets-encrypt-ocsp-stapling.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-configure-lets-encrypt-ocsp-stapling.yml
@@ -29,7 +29,7 @@
       bigip_device_info:
         gather_subset: devices
         provider:
-          user: "{{ bigip_user }}"
+          user: "{{ bigip_username }}"
           password: "{{ bigip_password }}"
           server: "{{ inventory_hostname }}"
           validate_certs: no

--- a/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-management.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-management.yml
@@ -14,7 +14,7 @@
       bigip_device_info:
         gather_subset: devices
         provider:
-          user: "{{ bigip_user }}"
+          user: "{{ bigip_username }}"
           password: "{{ bigip_password }}"
           server: "{{ inventory_hostname }}"
           validate_certs: no

--- a/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-traffic.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-deploy_cert-traffic.yml
@@ -29,7 +29,7 @@
       bigip_device_info:
         gather_subset: devices
         provider:
-          user: "{{ bigip_user }}"
+          user: "{{ bigip_username }}"
           password: "{{ bigip_password }}"
           server: "{{ inventory_hostname }}"
           validate_certs: no

--- a/etc/dehydrated/ansible/playbooks/bigip-deploy_challenge.yml
+++ b/etc/dehydrated/ansible/playbooks/bigip-deploy_challenge.yml
@@ -29,7 +29,7 @@
       bigip_device_info:
         gather_subset: devices
         provider:
-          user: "{{ bigip_user }}"
+          user: "{{ bigip_username }}"
           password: "{{ bigip_password }}"
           server: "{{ inventory_hostname }}"
           validate_certs: no


### PR DESCRIPTION
Various playbooks were failing with undefined-variable errors.

- All playbooks had typos of `bigip_user` instead of `bigip_username`.
- http01 validation hook was not passing device-sync-related variables
to `deploy_challenge` and `clean_challenge` playbooks.